### PR TITLE
docs(readme): remove quote of maxRank default

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ component output.
 ### Options
 
 - `name` (`string`) — The name of the variable to export the title as. (default: `'title'`)
-- `maxRank` (`number`) — The maximum heading rank to consider. (default: `'1'`)
+- `maxRank` (`number`) — The maximum heading rank to consider. (default: `1`)
 
 ## Compatibility
 


### PR DESCRIPTION
maxRank is number type, so we don't need quotes around `1`